### PR TITLE
regenerator runtime was missing; endsWith is not available in ie11

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
 ## Usage
 
 ```js
+import "regenerator-runtime/runtime"
 import '@webcomponents/webcomponentsjs'
 
 import Vue from 'vue'

--- a/src/index.js
+++ b/src/index.js
@@ -128,7 +128,7 @@ export default function wrap(Vue, Component, wrapOptions = {}) {
   }
 
   function syncAttribute(el, key) {
-    const jsonSuffixed = key.endsWith('-json')
+    const jsonSuffixed = key.indexOf('-json', this.length - '-json'.length) !== -1
     const camelized = camelize(key.replace(/-json$/, ''))
 
     const value = el.hasAttribute(key) ? el.getAttribute(key) : undefined


### PR DESCRIPTION
This fork was not instantly working for me in IE11.  I had to add regenerator runtime and replace endsWith with a more compatible implementation. 